### PR TITLE
Add JWT Bearer grant support to Invoke-OAuth2TokenEndpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ See links for function documentation, usage and examples.
 | -------- | ----------- |
 | [Invoke-OAuth2AuthorizationEndpoint](/docs/Invoke-OAuth2AuthorizationEndpoint.md) | Launches an embedded WebView2 browser to perform the OAuth2.0/OIDC Authorization Code flow. Supports modern authentication features (SSO, Windows Hello, FIDO2). | 
 | [Invoke-OAuth2DeviceAuthorizationEndpoint](/docs/Invoke-OAuth2DeviceAuthorizationEndpoint.md) | Initiates the Device Code flow by retrieving a user and device verification code from the authorization server that can be used to request tokens from the token endpoint. |
-| [Invoke-OAuth2TokenEndpoint](docs/Invoke-OAuth2TokenEndpoint.md) | Requests security tokens using various grant types: authorization code, device code, refresh token, client credentials, or JWT assertions.|
+| [Invoke-OAuth2TokenEndpoint](docs/Invoke-OAuth2TokenEndpoint.md) | Requests security tokens using various grant types: authorization code, device code, refresh token, client credentials, JWT assertions, or JWT Bearer (RFC 7523).|
 | [Get-OidcConfigurationMetadata](docs/Get-OidcDiscoveryMetadata.md) | Retrieves OpenID Connect Discovery metadata (`.well-known/openid-configuration`). |
 | [ConvertFrom-JsonWebToken](docs/ConvertFrom-JsonWebToken.md) | Decodes a JWT and returns a PowerShell object. | 
 | [Test-JsonWebTokenSignature](docs/Test-JsonWebTokenSignature.md) | Attempts to verify the JWT signature using the issuer’s published signing keys (via discovery metadata) or provided certificate/secret. | 
 | [New-PkceChallenge](docs/New-PkceChallenge.md) | Generates a PKCE `code_verifier` and `code_challenge` pair for Authorization Code flows. | 
-| [New-Oauth2JwtAssertion](docs/New-Oauth2JwtAssertion.md) | Builds and signs a JWT assertion using either a client certificate or HMAC secret, suitable for `private_key_jwt` or `client_secret_jwt` authentication methods.|
+| [New-Oauth2JwtAssertion](docs/New-Oauth2JwtAssertion.md) | Builds and signs a JWT assertion using either a client certificate (cert store path, x509certificate2, RSA key object, or PEM string) or HMAC secret, suitable for `private_key_jwt`, `client_secret_jwt`, or JWT Bearer grant flows.|
 | [Clear-WebView2Cache](docs/Clear-WebView2Cache.md) | Deletes the WebView2 User Data Folder to clear cached sessions and cookies. |
 
 <br>
@@ -459,6 +459,30 @@ expiry_datetime : 31.01.2024 15:07:19
 
 
 ```
+</details>
+
+<details>
+<summary><b>JWT Bearer Grant / Service Account (RFC 7523)</b></summary>
+
+Example using a Google service account key file.
+```powershell
+$keyData = Get-Content 'C:\keys\my-sa-key.json' | ConvertFrom-Json
+$jwt = New-Oauth2JwtAssertion `
+        -issuer             $keyData.client_email `
+        -subject            $keyData.client_email `
+        -audience           'https://oauth2.googleapis.com/token' `
+        -key_id             $keyData.private_key_id `
+        -client_certificate $keyData.private_key `
+        -customClaims       @{ scope = 'https://www.googleapis.com/auth/spreadsheets' }
+
+$token = Invoke-OAuth2TokenEndpoint -uri 'https://oauth2.googleapis.com/token' -jwtAssertion $jwt.client_assertion_jwt
+
+token_type      : Bearer
+expires_in      : 3599
+access_token    : ya29.c.b0ARPM...
+expiry_datetime : 05.04.2026 19:00:38
+```
+`New-Oauth2JwtAssertion` accepts the PEM `private_key` string directly from the JSON key file. The signed JWT is exchanged for an access token via the RFC 7523 JWT Bearer grant.
 </details>
 
 <details>

--- a/src/Invoke-OAuth2TokenEndpoint.ps1
+++ b/src/Invoke-OAuth2TokenEndpoint.ps1
@@ -45,6 +45,11 @@ function Invoke-OAuth2TokenEndpoint {
     .PARAMETER customHeaders
     Hashtable with custom headers to be added to the request uri (e.g. User-Agent, Origin, Referer, etc.).
 
+    .PARAMETER assertion
+    A pre-built signed JWT for the RFC 7523 JWT Bearer grant (grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer).
+    Build the JWT using New-Oauth2JwtAssertion, then pass the .client_assertion_jwt property here.
+    Used for flows like Google service account authentication where the JWT itself is the grant.
+
     .EXAMPLE
     PS> $code = Invoke-OAuth2AuthorizationEndpoint -uri $authorization_endpoint @splat
     PS> Invoke-OAuth2TokenEndpoint -uri $token_endpoint @code
@@ -79,6 +84,25 @@ function Invoke-OAuth2TokenEndpoint {
 
     Client authentication using private_key_jwt
 
+    .EXAMPLE
+    PS> $keyData = Get-Content 'C:\keys\my-sa-key.json' | ConvertFrom-Json
+    PS> $jwt = New-Oauth2JwtAssertion `
+            -issuer             $keyData.client_email `
+            -subject            $keyData.client_email `
+            -audience           'https://oauth2.googleapis.com/token' `
+            -key_id             $keyData.private_key_id `
+            -client_certificate $keyData.private_key `
+            -customClaims       @{ scope = 'https://www.googleapis.com/auth/spreadsheets' }
+    PS> Invoke-OAuth2TokenEndpoint -uri 'https://oauth2.googleapis.com/token' -jwtAssertion $jwt.client_assertion_jwt
+    token_type      : Bearer
+    expires_in      : 3599
+    access_token    : ya29.c.b0ARPM...
+    expiry_datetime : 05.04.2026 19:00:38
+
+    Google service account authentication using RFC 7523 JWT Bearer grant.
+    New-Oauth2JwtAssertion builds and signs the JWT (passing the PEM private_key string directly);
+    the signed JWT is exchanged for an access token via the jwt_bearer parameter set.
+
     #>
     [Alias('Invoke-TokenEndpoint','token')]
     [cmdletbinding(DefaultParameterSetName='code')]
@@ -88,6 +112,7 @@ function Invoke-OAuth2TokenEndpoint {
         [parameter( Position = 0, Mandatory = $true, ParameterSetName='code')]
         [parameter( Position = 0, Mandatory = $true, ParameterSetName='device_code')]
         [parameter( Position = 0, Mandatory = $true, ParameterSetName='refresh')]
+        [parameter( Position = 0, Mandatory = $true, ParameterSetName='jwt_bearer')]
         [string]$uri,
 
         [parameter( Mandatory = $false, ParameterSetName='client_certificate')]
@@ -150,7 +175,10 @@ function Invoke-OAuth2TokenEndpoint {
         [parameter( Mandatory = $false, ParameterSetName='code')]
         [parameter( Mandatory = $false, ParameterSetName='device_code')]
         [parameter( Mandatory = $false, ParameterSetName='refresh')]
-        [hashtable]$customHeaders
+        [hashtable]$customHeaders,
+
+        [parameter( Mandatory = $true, ParameterSetName='jwt_bearer')]
+        [string]$jwtAssertion
     )
 
     $payload = @{}
@@ -180,6 +208,10 @@ function Invoke-OAuth2TokenEndpoint {
     elseif ( $device_code ) { 
         $requestBody.grant_type = "urn:ietf:params:oauth:grant-type:device_code"
         $requestBody.device_code = $device_code
+    }
+    elseif ( $jwtAssertion ) {
+        $requestBody.grant_type = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+        $requestBody.assertion = $jwtAssertion
     }
     elseif ( $refresh_token ) { 
         $requestBody.grant_type = "refresh_token"

--- a/src/New-OAuth2JwtAssertion.ps1
+++ b/src/New-OAuth2JwtAssertion.ps1
@@ -22,7 +22,8 @@ function New-Oauth2JwtAssertion {
     Hashtable with custom claims to be added to the JWT payload (assertion).
 
     .PARAMETER client_certificate
-    Location Cert:\CurrentUser\My\THUMBPRINT, x509certificate2 or RSA Private key.
+    Location Cert:\CurrentUser\My\THUMBPRINT, x509certificate2, RSA private key object, or a PEM string
+    (must begin with '-----BEGIN PRIVATE KEY-----' and end with '-----END PRIVATE KEY-----').
 
     .PARAMETER key_id
     kid, key identifier for assertion header
@@ -74,8 +75,23 @@ function New-Oauth2JwtAssertion {
     # certificate properties
     if ( $client_certificate ) {
         if ( $client_certificate.GetType().Name -notmatch "^X509Certificate|^RSA" ) {
-            try { $client_certificate = Get-Item $client_certificate -ErrorAction Stop }
-            catch { throw $_ }
+            if ( $client_certificate -is [string] -and
+                 $client_certificate -match '^\s*-----BEGIN PRIVATE KEY-----' -and
+                 $client_certificate -match '-----END PRIVATE KEY-----\s*$' ) {
+                # PEM PKCS#8 private key string — import as RSA for signing
+                $pem      = $client_certificate `
+                                -replace '-----BEGIN PRIVATE KEY-----','' `
+                                -replace '-----END PRIVATE KEY-----','' `
+                                -replace '\s',''
+                $keyBytes  = [Convert]::FromBase64String($pem)
+                $rsa       = [System.Security.Cryptography.RSA]::Create()
+                $bytesRead = 0
+                $rsa.ImportPkcs8PrivateKey($keyBytes, [ref]$bytesRead)
+                $client_certificate = $rsa
+            } else {
+                try { $client_certificate = Get-Item $client_certificate -ErrorAction Stop }
+                catch { throw $_ }
+            }
         }
         if ( $client_certificate.GetType().Name -match "^X509Certificate" ) { $jwtHeader.x5t = ConvertTo-Base64urlencoding $client_certificate.GetCertHash() }
         if ( $key_id ) { $jwtHeader.kid = $key_id }


### PR DESCRIPTION
This PR adds to the Invoke-OAuth2TokenEndpoint and New-Oauth2JwtAssertion so we can pass a privatekey as string Primarily to make Google Service Account keys easier to interact with