### PR TITLE
Fix: handle 302 redirects to redirect_uri in WebView2 authorization flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ See links for function documentation, usage and examples.
 | -------- | ----------- |
 | [Invoke-OAuth2AuthorizationEndpoint](/docs/Invoke-OAuth2AuthorizationEndpoint.md) | Launches an embedded WebView2 browser to perform the OAuth2.0/OIDC Authorization Code flow. Supports modern authentication features (SSO, Windows Hello, FIDO2). | 
 | [Invoke-OAuth2DeviceAuthorizationEndpoint](/docs/Invoke-OAuth2DeviceAuthorizationEndpoint.md) | Initiates the Device Code flow by retrieving a user and device verification code from the authorization server that can be used to request tokens from the token endpoint. |
-| [Invoke-OAuth2TokenEndpoint](docs/Invoke-OAuth2TokenEndpoint.md) | Requests security tokens using various grant types: authorization code, device code, refresh token, client credentials, or JWT assertions.|
+| [Invoke-OAuth2TokenEndpoint](docs/Invoke-OAuth2TokenEndpoint.md) | Requests security tokens using various grant types: authorization code, device code, refresh token, client credentials, JWT assertions, or JWT Bearer (RFC 7523).|
 | [Get-OidcConfigurationMetadata](docs/Get-OidcDiscoveryMetadata.md) | Retrieves OpenID Connect Discovery metadata (`.well-known/openid-configuration`). |
 | [ConvertFrom-JsonWebToken](docs/ConvertFrom-JsonWebToken.md) | Decodes a JWT and returns a PowerShell object. | 
 | [Test-JsonWebTokenSignature](docs/Test-JsonWebTokenSignature.md) | Attempts to verify the JWT signature using the issuer’s published signing keys (via discovery metadata) or provided certificate/secret. | 
 | [New-PkceChallenge](docs/New-PkceChallenge.md) | Generates a PKCE `code_verifier` and `code_challenge` pair for Authorization Code flows. | 
-| [New-Oauth2JwtAssertion](docs/New-Oauth2JwtAssertion.md) | Builds and signs a JWT assertion using either a client certificate or HMAC secret, suitable for `private_key_jwt` or `client_secret_jwt` authentication methods.|
+| [New-Oauth2JwtAssertion](docs/New-Oauth2JwtAssertion.md) | Builds and signs a JWT assertion using either a client certificate (cert store path, x509certificate2, RSA key object, or PEM string) or HMAC secret, suitable for `private_key_jwt`, `client_secret_jwt`, or JWT Bearer grant flows.|
 | [Clear-WebView2Cache](docs/Clear-WebView2Cache.md) | Deletes the WebView2 User Data Folder to clear cached sessions and cookies. |
 
 <br>
@@ -459,6 +459,30 @@ expiry_datetime : 31.01.2024 15:07:19
 
 
 ```
+</details>
+
+<details>
+<summary><b>JWT Bearer Grant / Service Account (RFC 7523)</b></summary>
+
+Example using a Google service account key file.
+```powershell
+$keyData = Get-Content 'C:\keys\my-sa-key.json' | ConvertFrom-Json
+$jwt = New-Oauth2JwtAssertion `
+        -issuer             $keyData.client_email `
+        -subject            $keyData.client_email `
+        -audience           'https://oauth2.googleapis.com/token' `
+        -key_id             $keyData.private_key_id `
+        -client_certificate $keyData.private_key `
+        -customClaims       @{ scope = 'https://www.googleapis.com/auth/spreadsheets' }
+
+$token = Invoke-OAuth2TokenEndpoint -uri 'https://oauth2.googleapis.com/token' -jwtAssertion $jwt.client_assertion_jwt
+
+token_type      : Bearer
+expires_in      : 3599
+access_token    : ya29.c.b0ARPM...
+expiry_datetime : 05.04.2026 19:00:38
+```
+`New-Oauth2JwtAssertion` accepts the PEM `private_key` string directly from the JSON key file. The signed JWT is exchanged for an access token via the RFC 7523 JWT Bearer grant.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -467,13 +467,15 @@ expiry_datetime : 31.01.2024 15:07:19
 Example using a Google service account key file.
 ```powershell
 $keyData = Get-Content 'C:\keys\my-sa-key.json' | ConvertFrom-Json
-$jwt = New-Oauth2JwtAssertion `
-        -issuer             $keyData.client_email `
-        -subject            $keyData.client_email `
-        -audience           'https://oauth2.googleapis.com/token' `
-        -key_id             $keyData.private_key_id `
-        -client_certificate $keyData.private_key `
-        -customClaims       @{ scope = 'https://www.googleapis.com/auth/spreadsheets' }
+$splat = @{
+    issuer             = $keyData.client_email
+    subject            = $keyData.client_email
+    audience           = 'https://oauth2.googleapis.com/token'
+    key_id             = $keyData.private_key_id
+    client_certificate = $keyData.private_key
+    customClaims       = @{ scope = 'https://www.googleapis.com/auth/spreadsheets' }
+}
+$jwt = New-Oauth2JwtAssertion @splat
 
 $token = Invoke-OAuth2TokenEndpoint -uri 'https://oauth2.googleapis.com/token' -jwtAssertion $jwt.client_assertion_jwt
 

--- a/build/1_PSAuthClient.restorePackages.ps1
+++ b/build/1_PSAuthClient.restorePackages.ps1
@@ -29,5 +29,5 @@ copy-item -Recurse -Path "$basePath\packages\Microsoft.Web.WebView2.$webView2Ver
 copy-item -Recurse -Path "$basePath\packages\Microsoft.Web.WebView2.$webView2Version\lib_manual\netcoreapp3.0" -Destination "$releasePath\Microsoft.Web.WebView2.$webView2Version" -Force
 # runtime specific files
 foreach ( $runtime in (Get-ChildItem "$basePath\packages\Microsoft.Web.WebView2.$webView2Version\runtimes" -Directory) ) { 
-    copy-item -Recurse -Path "$runtime\native\" -Destination "$releasePath\Microsoft.Web.WebView2.$webView2Version\runtimes\$($runtime.name)\" -Force
+    copy-item -Recurse -Path "$($runtime.FullName)\native\" -Destination "$releasePath\Microsoft.Web.WebView2.$webView2Version\runtimes\$($runtime.name)\" -Force
 }

--- a/docs/Invoke-OAuth2TokenEndpoint.md
+++ b/docs/Invoke-OAuth2TokenEndpoint.md
@@ -19,6 +19,12 @@ Invoke-OAuth2TokenEndpoint [-uri] <String> [-client_id <String>] [-redirect_uri 
  [-customHeaders <Hashtable>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
+### jwt_bearer
+```powershell
+Invoke-OAuth2TokenEndpoint [-uri] <String> -jwtAssertion <String> [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
+```
+
 ### refresh
 ```powershell
 Invoke-OAuth2TokenEndpoint [-uri] <String> [-client_id <String>] [-redirect_uri <String>] [-scope <String>]
@@ -114,7 +120,7 @@ The identifier of the client at the authorisation server.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: code, refresh, device_code, client_secret, client_certificate
 Aliases:
 
 Required: False
@@ -300,13 +306,30 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -jwtAssertion
+A pre-built signed JWT for the RFC 7523 JWT Bearer grant (grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer).
+Build the JWT using New-Oauth2JwtAssertion, then pass the .client_assertion_jwt property here.
+Used for flows like Google service account authentication where the JWT itself is the grant.
+
+```yaml
+Type: String
+Parameter Sets: jwt_bearer
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -customHeaders
 Hashtable with custom headers to be added to the request uri (e.g.
 User-Agent, Origin, Referer, etc.).
 
 ```yaml
 Type: Hashtable
-Parameter Sets: (All)
+Parameter Sets: code, refresh, device_code, client_secret, client_certificate
 Aliases:
 
 Required: False

--- a/packages.config
+++ b/packages.config
@@ -6,5 +6,5 @@
   
   The 'Import-assemblies.ps1' script loads the appropriate assembly at runtime.
   -->
-  <package id="Microsoft.Web.WebView2" version="1.0.3296.44"/> 
+  <package id="Microsoft.Web.WebView2" version="1.0.3856.49"/> 
 </packages>

--- a/src/Invoke-OAuth2AuthorizationEndpoint.ps1
+++ b/src/Invoke-OAuth2AuthorizationEndpoint.ps1
@@ -56,7 +56,7 @@ function Invoke-OAuth2AuthorizationEndpoint {
 
     Implicit Grant, will return a access_token if successful.
     #>
-    [Alias('Invoke-AuthorizationEndpoint','authorize')]
+    [Alias('Invoke-AuthorizationEndpoint', 'authorize')]
     [OutputType([hashtable])]
     param(
         [parameter(Position = 0, Mandatory = $true)]
@@ -79,7 +79,7 @@ function Invoke-OAuth2AuthorizationEndpoint {
         [bool]$usePkce = $true,
 
         [parameter( Mandatory = $false)]
-        [ValidateSet("query","fragment","form_post")]
+        [ValidateSet("query", "fragment", "form_post")]
         [string]$response_mode,
 
         [parameter( Mandatory = $false)]
@@ -91,7 +91,8 @@ function Invoke-OAuth2AuthorizationEndpoint {
 
     # Determine which protocol is being used.
     if ( $response_type -eq "token" -or ($response_type -match "^code$" -and $scope -notmatch "openid" ) ) { $protocol = "OAUTH"; $nonce = $null }
-    else { $protocol = "OIDC"
+    else {
+        $protocol = "OIDC"
         # ensure scope contains openid for oidc flows
         if ( $scope -notmatch "openid" ) { Write-Warning "Invoke-OAuth2AuthorizationRequest: Added openid scope to request (OpenID requirement)."; $scope += " openid" }
         # ensure nonce is present for id_token validation
@@ -150,7 +151,7 @@ function Invoke-OAuth2AuthorizationEndpoint {
     $webViewParams.uri = $uri
     $webViewParams.title = "Authorization code flow"
     if ( $userAgent ) { $webViewParams.userAgent = $userAgent }
-    if ( $redirect_uri ) { $webViewParams.UrlCloseConditionRegex = "($($redirect_uri))?.*(?:code=([^&]+)|error=([^&]+))|^($($redirect_uri))" }
+    if ( $redirect_uri ) { $webViewParams.UrlCloseConditionRegex = "^$([regex]::Escape($redirect_uri)).*(?:code=([^&]+)|error=([^&]+))|^$([regex]::Escape($redirect_uri))" }
     else { $webViewParams.UrlCloseConditionRegex = "(?:code=([^&]+)|error=([^&]+))" }
     $webSource = Invoke-WebView2 @webViewParams
     
@@ -166,14 +167,13 @@ function Invoke-OAuth2AuthorizationEndpoint {
         catch { 
             if ( $_.Exception.Message -match "Access is denied." ) { throw "Unabled to start http.sys listener, please run as admin." }
             else { throw "http.sys listener failed, error: $($jobData.Exception.Message)" }
-        }
-        finally { Remove-Job $job }
+        } finally { Remove-Job $job }
         Write-Verbose "Invoke-OAuth2AuthorizationRequest: http.sys form_post request received."
         $webSource = @{ Fragment = $jobData; Query = $null }
     }
 
     # When the window closes (WebView2), the script will continue and retreive the depending on the response_mode and content.
-    if( $webSource.query -match "code=" ) {
+    if ( $webSource.query -match "code=" ) {
         $response = @{}
         $response.code = [System.Web.HttpUtility]::ParseQueryString($webSource.Query)['code']
         $response.state = [System.Web.HttpUtility]::ParseQueryString($webSource.Query)['state']
@@ -182,15 +182,13 @@ function Invoke-OAuth2AuthorizationEndpoint {
             if ( [System.Web.HttpUtility]::ParseQueryString($webSource.Query)['access_token'] ) { $response.access_token = [System.Web.HttpUtility]::ParseQueryString($webSource.Query)['access_token'] }
             if ( [System.Web.HttpUtility]::ParseQueryString($webSource.Query)['id_token'] ) { $response.access_token = [System.Web.HttpUtility]::ParseQueryString($webSource.Query)['id_token'] }
         }
-    } 
-    elseif ( $webSource.Query -match "error=" ) { 
+    } elseif ( $webSource.Query -match "error=" ) { 
         $errorDetails = [ordered]@{}
         $errorDetails.error = [System.Web.HttpUtility]::ParseQueryString($webSource.Query)['error']
         $errorDetails.error_uri = [System.Web.HttpUtility]::ParseQueryString($webSource.Query)['error_uri']
         $errorDetails.error_description = [System.Web.HttpUtility]::ParseQueryString($webSource.Query)['error_description']
         throw ($errorDetails | convertTo-Json)
-    }
-    elseif ( $webSource.Fragment -match "token|error=" ) {
+    } elseif ( $webSource.Fragment -match "token|error=" ) {
         $response = @{}
         foreach ( $item in (($webSource.Fragment -split "#|&") | Where-Object { $_ -ne "" }) ) { 
             $key = $item.split("=")[0]
@@ -200,8 +198,7 @@ function Invoke-OAuth2AuthorizationEndpoint {
         }
         if ( $protocol -eq "oidc" ) { $response.nonce = $nonce }
         if ( $webSource.Fragment -match "error=" ) { throw ($response | Select-Object * -ExcludeProperty state | convertTo-Json) }
-    }
-    else { throw "invalid response received" }
+    } else { throw "invalid response received" }
 
     # if code grant, add client_id, code_verifier and redirect_uri to output (needed for token exchange) 
     if ( $response_type -match "code" ) {

--- a/src/Invoke-OAuth2TokenEndpoint.ps1
+++ b/src/Invoke-OAuth2TokenEndpoint.ps1
@@ -45,6 +45,11 @@ function Invoke-OAuth2TokenEndpoint {
     .PARAMETER customHeaders
     Hashtable with custom headers to be added to the request uri (e.g. User-Agent, Origin, Referer, etc.).
 
+    .PARAMETER assertion
+    A pre-built signed JWT for the RFC 7523 JWT Bearer grant (grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer).
+    Build the JWT using New-Oauth2JwtAssertion, then pass the .client_assertion_jwt property here.
+    Used for flows like Google service account authentication where the JWT itself is the grant.
+
     .EXAMPLE
     PS> $code = Invoke-OAuth2AuthorizationEndpoint -uri $authorization_endpoint @splat
     PS> Invoke-OAuth2TokenEndpoint -uri $token_endpoint @code
@@ -79,6 +84,25 @@ function Invoke-OAuth2TokenEndpoint {
 
     Client authentication using private_key_jwt
 
+    .EXAMPLE
+    PS> $keyData = Get-Content 'C:\keys\my-sa-key.json' | ConvertFrom-Json
+    PS> $jwt = New-Oauth2JwtAssertion `
+            -issuer             $keyData.client_email `
+            -subject            $keyData.client_email `
+            -audience           'https://oauth2.googleapis.com/token' `
+            -key_id             $keyData.private_key_id `
+            -client_certificate $keyData.private_key `
+            -customClaims       @{ scope = 'https://www.googleapis.com/auth/spreadsheets' }
+    PS> Invoke-OAuth2TokenEndpoint -uri 'https://oauth2.googleapis.com/token' -jwtAssertion $jwt.client_assertion_jwt
+    token_type      : Bearer
+    expires_in      : 3599
+    access_token    : ya29.c.b0ARPM...
+    expiry_datetime : 05.04.2026 19:00:38
+
+    Google service account authentication using RFC 7523 JWT Bearer grant.
+    New-Oauth2JwtAssertion builds and signs the JWT (passing the PEM private_key string directly);
+    the signed JWT is exchanged for an access token via the jwt_bearer parameter set.
+
     #>
     [Alias('Invoke-TokenEndpoint','token')]
     [cmdletbinding(DefaultParameterSetName='code')]
@@ -88,6 +112,7 @@ function Invoke-OAuth2TokenEndpoint {
         [parameter( Position = 0, Mandatory = $true, ParameterSetName='code')]
         [parameter( Position = 0, Mandatory = $true, ParameterSetName='device_code')]
         [parameter( Position = 0, Mandatory = $true, ParameterSetName='refresh')]
+        [parameter( Position = 0, Mandatory = $true, ParameterSetName='jwt_bearer')]
         [string]$uri,
 
         [parameter( Mandatory = $false, ParameterSetName='client_certificate')]
@@ -150,7 +175,10 @@ function Invoke-OAuth2TokenEndpoint {
         [parameter( Mandatory = $false, ParameterSetName='code')]
         [parameter( Mandatory = $false, ParameterSetName='device_code')]
         [parameter( Mandatory = $false, ParameterSetName='refresh')]
-        [hashtable]$customHeaders
+        [hashtable]$customHeaders,
+
+        [parameter( Mandatory = $true, ParameterSetName='jwt_bearer')]
+        [string]$jwtAssertion
     )
 
     $payload = @{}
@@ -180,6 +208,10 @@ function Invoke-OAuth2TokenEndpoint {
     elseif ( $device_code ) { 
         $requestBody.grant_type = "urn:ietf:params:oauth:grant-type:device_code"
         $requestBody.device_code = $device_code
+    }
+    elseif ( $jwtAssertion ) {
+        $requestBody.grant_type = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+        $requestBody.assertion = $jwtAssertion
     }
     elseif ( $refresh_token ) { 
         $requestBody.grant_type = "refresh_token"

--- a/src/Invoke-OAuth2TokenEndpoint.ps1
+++ b/src/Invoke-OAuth2TokenEndpoint.ps1
@@ -42,13 +42,13 @@ function Invoke-OAuth2TokenEndpoint {
     .PARAMETER refresh_token
     Refresh token received from the authorization server.
 
-    .PARAMETER customHeaders
-    Hashtable with custom headers to be added to the request uri (e.g. User-Agent, Origin, Referer, etc.).
-
-    .PARAMETER assertion
+    .PARAMETER jwtAssertion
     A pre-built signed JWT for the RFC 7523 JWT Bearer grant (grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer).
     Build the JWT using New-Oauth2JwtAssertion, then pass the .client_assertion_jwt property here.
     Used for flows like Google service account authentication where the JWT itself is the grant.
+
+    .PARAMETER customHeaders
+    Hashtable with custom headers to be added to the request uri (e.g. User-Agent, Origin, Referer, etc.).
 
     .EXAMPLE
     PS> $code = Invoke-OAuth2AuthorizationEndpoint -uri $authorization_endpoint @splat
@@ -85,15 +85,17 @@ function Invoke-OAuth2TokenEndpoint {
     Client authentication using private_key_jwt
 
     .EXAMPLE
-    PS> $keyData = Get-Content 'C:\keys\my-sa-key.json' | ConvertFrom-Json
-    PS> $jwt = New-Oauth2JwtAssertion `
-            -issuer             $keyData.client_email `
-            -subject            $keyData.client_email `
-            -audience           'https://oauth2.googleapis.com/token' `
-            -key_id             $keyData.private_key_id `
-            -client_certificate $keyData.private_key `
-            -customClaims       @{ scope = 'https://www.googleapis.com/auth/spreadsheets' }
-    PS> Invoke-OAuth2TokenEndpoint -uri 'https://oauth2.googleapis.com/token' -jwtAssertion $jwt.client_assertion_jwt
+    $keyData = Get-Content 'C:\keys\my-sa-key.json' | ConvertFrom-Json
+    $splat = @{
+        issuer             = $keyData.client_email
+        subject            = $keyData.client_email
+        audience           = 'https://oauth2.googleapis.com/token'
+        key_id             = $keyData.private_key_id
+        client_certificate = $keyData.private_key
+        customClaims       = @{ scope = 'https://www.googleapis.com/auth/spreadsheets' }
+    }
+    $jwt = New-Oauth2JwtAssertion @splat
+    Invoke-OAuth2TokenEndpoint -uri 'https://oauth2.googleapis.com/token' -jwtAssertion $jwt.client_assertion_jwt
     token_type      : Bearer
     expires_in      : 3599
     access_token    : ya29.c.b0ARPM...
@@ -170,15 +172,16 @@ function Invoke-OAuth2TokenEndpoint {
         [parameter( Mandatory = $true, ParameterSetName='refresh')]
         $refresh_token,
 
+        [parameter( Mandatory = $true, ParameterSetName='jwt_bearer')]
+        [string]$jwtAssertion,
+
         [parameter( Mandatory = $false, ParameterSetName='client_certificate')]
         [parameter( Mandatory = $false, ParameterSetName='client_secret')]
         [parameter( Mandatory = $false, ParameterSetName='code')]
         [parameter( Mandatory = $false, ParameterSetName='device_code')]
         [parameter( Mandatory = $false, ParameterSetName='refresh')]
-        [hashtable]$customHeaders,
+        [hashtable]$customHeaders
 
-        [parameter( Mandatory = $true, ParameterSetName='jwt_bearer')]
-        [string]$jwtAssertion
     )
 
     $payload = @{}

--- a/src/New-OAuth2JwtAssertion.ps1
+++ b/src/New-OAuth2JwtAssertion.ps1
@@ -22,7 +22,8 @@ function New-Oauth2JwtAssertion {
     Hashtable with custom claims to be added to the JWT payload (assertion).
 
     .PARAMETER client_certificate
-    Location Cert:\CurrentUser\My\THUMBPRINT, x509certificate2 or RSA Private key.
+    Location Cert:\CurrentUser\My\THUMBPRINT, x509certificate2, RSA private key object, or a PEM string
+    (must begin with '-----BEGIN PRIVATE KEY-----' and end with '-----END PRIVATE KEY-----').
 
     .PARAMETER key_id
     kid, key identifier for assertion header
@@ -74,8 +75,23 @@ function New-Oauth2JwtAssertion {
     # certificate properties
     if ( $client_certificate ) {
         if ( $client_certificate.GetType().Name -notmatch "^X509Certificate|^RSA" ) {
-            try { $client_certificate = Get-Item $client_certificate -ErrorAction Stop }
-            catch { throw $_ }
+            if ( $client_certificate -is [string] -and
+                 $client_certificate -match '^\s*-----BEGIN PRIVATE KEY-----' -and
+                 $client_certificate -match '-----END PRIVATE KEY-----\s*$' ) {
+                # PEM PKCS#8 private key string — import as RSA for signing
+                $pem      = $client_certificate `
+                                -replace '-----BEGIN PRIVATE KEY-----','' `
+                                -replace '-----END PRIVATE KEY-----','' `
+                                -replace '\s',''
+                $keyBytes  = [Convert]::FromBase64String($pem)
+                $rsa       = [System.Security.Cryptography.RSA]::Create()
+                $bytesRead = 0
+                $rsa.ImportPkcs8PrivateKey($keyBytes, [ref]$bytesRead)
+                $client_certificate = $rsa
+            } else {
+                try { $client_certificate = Get-Item $client_certificate -ErrorAction Stop }
+                catch { throw $_ }
+            }
         }
         if ( $client_certificate.GetType().Name -match "^X509Certificate" ) { $jwtHeader.x5t = ConvertTo-Base64urlencoding $client_certificate.GetCertHash() }
         if ( $key_id ) { $jwtHeader.kid = $key_id }

--- a/src/New-OAuth2JwtAssertion.ps1
+++ b/src/New-OAuth2JwtAssertion.ps1
@@ -76,9 +76,10 @@ function New-Oauth2JwtAssertion {
     if ( $client_certificate ) {
         if ( $client_certificate.GetType().Name -notmatch "^X509Certificate|^RSA" ) {
             if ( $client_certificate -is [string] -and
-                 $client_certificate -match '^\s*-----BEGIN PRIVATE KEY-----' -and
-                 $client_certificate -match '-----END PRIVATE KEY-----\s*$' ) {
+                $client_certificate -match '^\s*-----BEGIN PRIVATE KEY-----' -and
+                $client_certificate -match '-----END PRIVATE KEY-----\s*$' ) {
                 # PEM PKCS#8 private key string — import as RSA for signing
+                if ($PSVersionTable.PSEdition -ne 'Core') { throw "PEM private key import requires PowerShell 7+. Use a certificate from Cert:\ or an X509Certificate2 object instead." }
                 $pem      = $client_certificate `
                                 -replace '-----BEGIN PRIVATE KEY-----','' `
                                 -replace '-----END PRIVATE KEY-----','' `

--- a/src/internal/Invoke-WebView2.ps1
+++ b/src/internal/Invoke-WebView2.ps1
@@ -37,28 +37,28 @@ function Invoke-WebView2 {
 
     #>
     param(
-        [parameter(Position = 0, Mandatory = $true, HelpMessage="The URL to browse.")]
+        [parameter(Position = 0, Mandatory = $true, HelpMessage = "The URL to browse.")]
         [string]$uri,
 
-        [parameter( Mandatory = $false, HelpMessage="Form close condition by regex (URL)")]
+        [parameter( Mandatory = $false, HelpMessage = "Form close condition by regex (URL)")]
         [string]$UrlCloseConditionRegex = "error=[^&]*",
 
-        [parameter( Mandatory = $false, HelpMessage="WebView2 failover to System.Windows.Forms.WebBrowser (IE11)")]
+        [parameter( Mandatory = $false, HelpMessage = "WebView2 failover to System.Windows.Forms.WebBrowser (IE11)")]
         [bool]$failoverToWindowsFormsWebBrowser = $true,
 
-        [parameter( Mandatory = $false, HelpMessage="msSingleSignOnOSForPrimaryAccountIsShared")]
+        [parameter( Mandatory = $false, HelpMessage = "msSingleSignOnOSForPrimaryAccountIsShared")]
         [bool]$allowSingleSignOnUsingOSPrimaryAccount = $true,
 
-        [parameter( Mandatory = $false, HelpMessage="Forms window title")]
+        [parameter( Mandatory = $false, HelpMessage = "Forms window title")]
         [string]$title = "PowerShell WebView",
 
-        [parameter( Mandatory = $false, HelpMessage="Forms window width")]
+        [parameter( Mandatory = $false, HelpMessage = "Forms window width")]
         [int]$Width = "600",
 
-        [parameter( Mandatory = $false, HelpMessage="Forms window height")]
+        [parameter( Mandatory = $false, HelpMessage = "Forms window height")]
         [int]$Height = "800",
 
-        [parameter( Mandatory = $false, HelpMessage="Customize the User-Agent presented in the HTTP Header.")]
+        [parameter( Mandatory = $false, HelpMessage = "Customize the User-Agent presented in the HTTP Header.")]
         $userAgent
     
     )
@@ -72,11 +72,24 @@ function Invoke-WebView2 {
         $web.CreationProperties.UserDataFolder = "$env:temp\PSAuthClientWebview2Cache\" 
         $web.Dock = "Fill"
         $web.source = $uri
-        if ( $userAgent ) { $web.add_CoreWebView2InitializationCompleted({$web.CoreWebView2.Settings.UserAgent = $userAgent}) }
+        if ( $userAgent ) { $web.add_CoreWebView2InitializationCompleted({ $web.CoreWebView2.Settings.UserAgent = $userAgent }) }
+        
+        # close form on completion (match redirectUri) navigation
+        # Fix if the redirectUri is a 302 redirect, the SourceChanged event will not be triggered, so we need to use the NavigationStarting event to catch it.
+        $web.Add_NavigationStarting({
+                param($_sender, $e)
+                Write-Debug "Invoke-WebView2: NavigationStarting event triggered with URL: $($e.Uri)"
+                if ( $e.Uri -match $UrlCloseConditionRegex ) {
+                    $Form.Tag = $e.Uri
+                    $e.Cancel = $true            # prevent navigation to the redirectUri, so we can capture the URL and close the form
+                    $Form.Close() | Out-Null
+                }
+            })
+        
         # close form on completion (match redirectUri) navigation
         $web.Add_SourceChanged( {
-            if ( $web.source.AbsoluteUri -match $UrlCloseConditionRegex )  { $Form.close() | Out-Null }
-        })
+                if ( $web.source.AbsoluteUri -match $UrlCloseConditionRegex ) { $Form.close() | Out-Null }
+            })
     }
     # if WebView2 fails to initialize, try to use Windows.Forms.WebBrowser
     catch {
@@ -86,21 +99,21 @@ function Invoke-WebView2 {
             $web = New-Object -TypeName System.Windows.Forms.WebBrowser -Property @{Width = $Width; Height = $Height; Url = $uri }
             # Close form on completion (match redirectUri) navigation
             $docCompletedEvent = {
-                if ( $web.Url.AbsoluteUri -match $UrlCloseConditionRegex )  { $form.Close() }
+                if ( $web.Url.AbsoluteUri -match $UrlCloseConditionRegex ) { $form.Close() }
             }
             $web.Add_DocumentCompleted($docCompletedEvent)
             $web.ScriptErrorsSuppressed = $true
             $title = $title + " [COMPATABILITY MODE]"
-    }
-        else { throw $_ }
+        } else { throw $_ }
     }
     # Create form
-    $form = New-Object System.Windows.Forms.Form -Property @{Width=$Width;Height=$Height;Text=$title} -ErrorAction Stop
+    $form = New-Object System.Windows.Forms.Form -Property @{Width = $Width; Height = $Height; Text = $title } -ErrorAction Stop
     # Add the WebBrowser control to the form
     $form.Controls.Add($web)
     $form.Add_Shown( { $form.Activate() } )
     $form.ShowDialog() | Out-Null
-    $response = $web.Source
+    if ( $form.Tag ) { $response = [uri]::new($form.Tag) }
+    else { $response = $web.Source }
     $web.Dispose()
     return $response
 }


### PR DESCRIPTION
## Summary

When the `redirect_uri` is reached through an HTTP 302 redirect, the WebView2
`SourceChanged` event does not fire. As a result, the authorization window
never closes and the authorization `code` (or error) cannot be captured,
leaving the flow hanging.

## Changes

- **`Invoke-WebView2.ps1`**: Add a `NavigationStarting` event handler that
  matches the close-condition regex. When the `redirect_uri` is hit, it cancels
  the navigation, stores the URL in `Form.Tag` and closes the form. The captured
  URL is then used as the response when present (falling back to `$web.Source`
  otherwise).
- **`Invoke-OAuth2AuthorizationEndpoint.ps1`**: Escape and anchor the
  `redirect_uri` in `UrlCloseConditionRegex` using `[regex]::Escape()`, so that
  regex metacharacters in the URI (e.g. `?`, `.`) no longer break the match.
- Apply consistent code formatting (whitespace only) across both files.

## Testing

Tested authorization code flow against private IdP with a redirect_uri
that returns a 302; window now closes and the code is captured correctly.
